### PR TITLE
Added parameter for returning positive pixels pairs

### DIFF
--- a/pixel_level_contrastive_learning/pixel_level_contrastive_learning.py
+++ b/pixel_level_contrastive_learning/pixel_level_contrastive_learning.py
@@ -273,7 +273,8 @@ class PixelCL(nn.Module):
         use_pixpro = True,
         cutout_ratio_range = (0.6, 0.8),
         cutout_interpolate_mode = 'nearest',
-        coord_cutout_interpolate_mode = 'bilinear'
+        coord_cutout_interpolate_mode = 'bilinear',
+        return_positive_pairs = False
     ):
         super().__init__()
 
@@ -425,7 +426,10 @@ class PixelCL(nn.Module):
         instance_loss = (loss_instance_one + loss_instance_two).mean()
 
         if positive_pixel_pairs == 0:
-            return instance_loss, 0
+            if return_positive_pairs:
+                return instance_loss, 0
+            else:
+                return instance_loss
 
         if not self.use_pixpro:
             # calculate pix contrast loss
@@ -465,4 +469,8 @@ class PixelCL(nn.Module):
         # total loss
 
         loss = pix_loss * self.alpha + instance_loss
-        return loss, positive_pixel_pairs
+
+        if return_positive_pairs:
+            return loss, positive_pixel_pairs
+        else:
+            return loss

--- a/pixel_level_contrastive_learning/pixel_level_contrastive_learning.py
+++ b/pixel_level_contrastive_learning/pixel_level_contrastive_learning.py
@@ -306,14 +306,16 @@ class PixelCL(nn.Module):
         self.alpha = alpha
 
         self.use_pixpro = use_pixpro
-
+        
         if use_pixpro:
             self.propagate_pixels = PPM(
                 chan = projection_size,
                 num_layers = ppm_num_layers,
                 gamma = ppm_gamma
             )
-
+        
+        self.return_positive_pairs = return_positive_pairs
+        
         self.cutout_ratio_range = cutout_ratio_range
         self.cutout_interpolate_mode = cutout_interpolate_mode
         self.coord_cutout_interpolate_mode = coord_cutout_interpolate_mode
@@ -426,7 +428,7 @@ class PixelCL(nn.Module):
         instance_loss = (loss_instance_one + loss_instance_two).mean()
 
         if positive_pixel_pairs == 0:
-            if return_positive_pairs:
+            if self.return_positive_pairs:
                 return instance_loss, 0
             else:
                 return instance_loss
@@ -470,7 +472,7 @@ class PixelCL(nn.Module):
 
         loss = pix_loss * self.alpha + instance_loss
 
-        if return_positive_pairs:
+        if self.return_positive_pairs:
             return loss, positive_pixel_pairs
         else:
             return loss


### PR DESCRIPTION
As discussed [here](https://github.com/lucidrains/pixel-level-contrastive-learning/issues/11) and to avoid waiting for a pytorch-lightning new version I created this pull request to bypass the problem that occurs when using multi-gpu for training.
Basically it adds a parameter to the model where the user can choose to return the positive pixels matrix or not. It needs to be set on False to avoid [this](https://github.com/PyTorchLightning/pytorch-lightning/issues/5585) error.
When set on True : model.forward() returns both the loss and the positive pixel pairs matrix
When set on False : model. forward() only returns the loss.